### PR TITLE
Fix #70 actus-ember - "Must use import to load ES Module" error

### DIFF
--- a/packages/actus-ember/package.json
+++ b/packages/actus-ember/package.json
@@ -4,8 +4,7 @@
   "description": "Ember bindings for actus",
   "keywords": [
     "actus",
-    "ember",
-    "ember-addon"
+    "ember"
   ],
   "repository": "https://github.com/EvgenyOrekhov/actus/tree/master/packages/actus-ember",
   "license": "MIT",


### PR DESCRIPTION
Apparently, Ember's [PackageInfo](https://github.com/ember-cli/ember-cli/blob/v3.17.0/lib/models/package-info-cache/package-info.js) module looks at the keywords declared in every package's `package.json` and does something weird if there is the `ember-addon` keyword.

actus-ember is not really an Ember addon because it doesn't use the [Ember addon file structure](https://cli.emberjs.com/release/writing-addons/). That's why the "Must use import to load ES Module" error was being thrown.

The fix was a lucky guess after a couple of hours of unfruitful googling and trying different things.

This was the stupidest thing I have ever seen in my entire programming career.