### PR TITLE
defaultActions - improve string and array

### DIFF
--- a/packages/actus/src/plugins/defaultActions/makeDefaultActions.js
+++ b/packages/actus/src/plugins/defaultActions/makeDefaultActions.js
@@ -1,5 +1,9 @@
 import mergeDeepRight from "ramda/src/mergeDeepRight.js";
 
+function castToString(value) {
+  return value === undefined || value === null ? "" : String(value);
+}
+
 export default function makeDefaultActions(initialState) {
   const defaultActions = {
     number: {
@@ -18,10 +22,10 @@ export default function makeDefaultActions(initialState) {
     },
 
     string: {
-      set: ({ payload }) => String(payload),
+      set: ({ payload }) => castToString(payload),
       reset: () => initialState,
       clear: () => "",
-      concat: ({ state, payload }) => state + payload,
+      concat: ({ state, payload }) => state + castToString(payload),
     },
 
     object: {

--- a/packages/actus/src/plugins/defaultActions/makeDefaultActions.js
+++ b/packages/actus/src/plugins/defaultActions/makeDefaultActions.js
@@ -4,6 +4,10 @@ function castToString(value) {
   return value === undefined || value === null ? "" : String(value);
 }
 
+function castToArray(value) {
+  return value === undefined || value === null ? [] : Array.from(value);
+}
+
 export default function makeDefaultActions(initialState) {
   const defaultActions = {
     number: {
@@ -43,12 +47,12 @@ export default function makeDefaultActions(initialState) {
     },
 
     array: {
-      set: ({ payload }) => payload,
+      set: ({ payload }) => castToArray(payload),
       reset: () => initialState,
       clear: () => [],
       append: ({ state, payload }) => [...state, payload],
       prepend: ({ state, payload }) => [payload, ...state],
-      concat: ({ state, payload }) => [...state, ...payload],
+      concat: ({ state, payload }) => [...state, ...castToArray(payload)],
     },
   };
 

--- a/packages/actus/src/plugins/defaultActions/makeDefaultActions.test.js
+++ b/packages/actus/src/plugins/defaultActions/makeDefaultActions.test.js
@@ -60,6 +60,28 @@ test("string", () => {
   expect(concat({ state: "baz", payload: "bar" })).toStrictEqual("bazbar");
 });
 
+test("string - set() - undefined and null", () => {
+  const { concat } = makeDefaultActions("foo");
+
+  expect(concat({ state: "baz", payload: undefined })).toStrictEqual("baz");
+
+  // eslint-disable-next-line unicorn/no-null
+  expect(concat({ state: "baz", payload: null })).toStrictEqual("baz");
+
+  expect(concat({ state: "baz", payload: false })).toStrictEqual("bazfalse");
+});
+
+test("string - concat() - undefined and null", () => {
+  const { set } = makeDefaultActions("foo");
+
+  expect(set({ state: "baz", payload: undefined })).toStrictEqual("");
+
+  // eslint-disable-next-line unicorn/no-null
+  expect(set({ state: "baz", payload: null })).toStrictEqual("");
+
+  expect(set({ state: "baz", payload: false })).toStrictEqual("false");
+});
+
 test("object", () => {
   const { set, reset, clear, merge, mergeDeep, remove } = makeDefaultActions({
     foo: "bar",

--- a/packages/actus/src/plugins/defaultActions/makeDefaultActions.test.js
+++ b/packages/actus/src/plugins/defaultActions/makeDefaultActions.test.js
@@ -2,6 +2,11 @@
 
 import makeDefaultActions from "./makeDefaultActions.js";
 
+function* iterator() {
+  yield 23;
+  yield 42;
+}
+
 test("number", () => {
   const { set, increment, decrement } = makeDefaultActions(0);
 
@@ -178,6 +183,79 @@ test("array", () => {
     16,
   ]);
   expect(concat({ state: [4, 8, 15, 16], payload: [23, 42] })).toStrictEqual([
+    4,
+    8,
+    15,
+    16,
+    23,
+    42,
+  ]);
+});
+
+test("array - set() - falsy values", () => {
+  const { set } = makeDefaultActions([4, 8, 15, 16]);
+
+  expect(set({ state: [4, 8, 15, 16], payload: undefined })).toStrictEqual([]);
+
+  // eslint-disable-next-line unicorn/no-null
+  expect(set({ state: [4, 8, 15, 16], payload: null })).toStrictEqual([]);
+
+  expect(set({ state: [4, 8, 15, 16], payload: false })).toStrictEqual([]);
+  expect(set({ state: [4, 8, 15, 16], payload: 0 })).toStrictEqual([]);
+  expect(set({ state: [4, 8, 15, 16], payload: Number.NaN })).toStrictEqual([]);
+});
+
+test("array - set() - array-like", () => {
+  const { set } = makeDefaultActions([4, 8, 15, 16]);
+
+  expect(set({ state: [4, 8, 15, 16], payload: iterator() })).toStrictEqual([
+    23,
+    42,
+  ]);
+});
+
+test("array - concat() - falsy values", () => {
+  const { concat } = makeDefaultActions([4, 8, 15, 16]);
+
+  expect(concat({ state: [4, 8, 15, 16], payload: undefined })).toStrictEqual([
+    4,
+    8,
+    15,
+    16,
+  ]);
+
+  // eslint-disable-next-line unicorn/no-null
+  expect(concat({ state: [4, 8, 15, 16], payload: null })).toStrictEqual([
+    4,
+    8,
+    15,
+    16,
+  ]);
+
+  expect(concat({ state: [4, 8, 15, 16], payload: false })).toStrictEqual([
+    4,
+    8,
+    15,
+    16,
+  ]);
+  expect(concat({ state: [4, 8, 15, 16], payload: 0 })).toStrictEqual([
+    4,
+    8,
+    15,
+    16,
+  ]);
+  expect(concat({ state: [4, 8, 15, 16], payload: Number.NaN })).toStrictEqual([
+    4,
+    8,
+    15,
+    16,
+  ]);
+});
+
+test("array - concat() - array-like", () => {
+  const { concat } = makeDefaultActions([4, 8, 15, 16]);
+
+  expect(concat({ state: [4, 8, 15, 16], payload: iterator() })).toStrictEqual([
     4,
     8,
     15,


### PR DESCRIPTION
- treat `undefined` and `null` as `""` for `string.set()` and `string.concat()`
- treat falsy values as `[]` for `array.set()` and `array.concat()`
- add support for array-like values to `array.set()` and `array.concat()` by the means of `Array.from()`