### PR TITLE
Fix #114 Add support for different types of storages

### DIFF
--- a/packages/actus/src/plugins/persist/index.js
+++ b/packages/actus/src/plugins/persist/index.js
@@ -7,7 +7,7 @@ export default function persist({
 } = {}) {
   function getStateFromStorage() {
     try {
-      return JSON.parse(storage[key]);
+      return JSON.parse(storage.getItem(key)) ?? undefined;
     } catch {
       return undefined;
     }
@@ -18,8 +18,7 @@ export default function persist({
 
     subscribers: [
       function saveStateToStorage({ state }) {
-        // eslint-disable-next-line fp/no-mutation, no-param-reassign
-        storage[key] = JSON.stringify(selector(state));
+        storage.setItem(key, JSON.stringify(selector(state)));
       },
     ],
   };


### PR DESCRIPTION
Use the [`Storage`](https://developer.mozilla.org/en-US/docs/Web/API/Storage) interface of the [Web Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API).

Fix #114